### PR TITLE
Add queries for POIs

### DIFF
--- a/data/pois.query
+++ b/data/pois.query
@@ -1,0 +1,5 @@
+nwr["traffic_intervention"="modal_filter"]
+nwr["shop"="bicycle"]
+nwr["amenity"="bicycle_parking"]
+nwr["amenity"="bicycle_repair_station"]
+nwr["amenity"="drinking_water"]


### PR DESCRIPTION
First stab at some POIs that would be useful on a bike map. I was wondering whether to add pubs and cafes, but then you could argue restaurants and hotels too? The list of objects we return can be exhaustive though, the layer styling determines what actually ends up on a map, so we can pull in more than we intend to use in these queries.